### PR TITLE
Remove `#[derive(Debug)]` from statement

### DIFF
--- a/bitfield-register-macro/src/lib.rs
+++ b/bitfield-register-macro/src/lib.rs
@@ -334,7 +334,6 @@ pub fn register(_: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    #[derive(Debug)]
     let mut bitfields: Vec<BitField> = vec![];
 
     for field in &fields {


### PR DESCRIPTION
`#[derive]` only affects structs, enums, and unions